### PR TITLE
Add configurable role for user logging in via given client

### DIFF
--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -1,0 +1,46 @@
+<?php
+
+use Drupal\user\UserInterface;
+
+/**
+ * OpenID Connect post authorize hook.
+ *
+ * This hook runs after a user has been authorized and claims have been mapped
+ * to the user's account.
+ *
+ * A popular use case for this hook is to saving token and additional identity
+ * provider related information to the user's Drupal session (private temp
+ * store).
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   User account object of the authorized user.
+ * @param array $context
+ *   An associative array with context information:
+ *   - tokens:         An array of tokens.
+ *   - user_data:      An array of user and session data.*
+ *   - plugin_id:      The plugin identifier.
+ *   - sub:            The remote user identifier.
+ *
+ * @ingroup openid_connect_api
+ * @throws \Drupal\Core\Entity\EntityStorageException
+ */
+function helfi_tunnistamo_openid_connect_post_authorize(UserInterface $account, array $context) {
+
+  $pluginConfigName = 'openid_connect.client.' . $context["plugin_id"];
+
+  /** @var \Drupal\Core\Config\ImmutableConfig $config */
+  $config = \Drupal::configFactory()->get($pluginConfigName)->get('settings');
+
+  // First remove all existing roles
+  $accountRoles = $account->getRoles(true);
+  foreach ($accountRoles as $role) {
+    $account->removeRole($role);
+  }
+
+  if (isset($config['client_roles']) && !empty($config['client_roles'])) {
+    foreach (explode(',',$config['client_roles']) as $role) {
+      $account->addRole($role);
+    }
+    $account->save();
+  }
+}

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -73,6 +73,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       'client_scopes' => 'openid,email',
       'environment_url' => 'https://tunnistamo.test.hel.ninja',
       'auto_login' => FALSE,
+      'client_roles' => '',
     ] + parent::defaultConfiguration();
   }
 
@@ -170,6 +171,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   ): array {
     $form = parent::buildConfigurationForm($form, $form_state);
 
+    $roles = array_keys(\Drupal::entityTypeManager()->getStorage('user_role')->loadMultiple());
+
     $form['is_production'] = [
       '#type' => 'checkbox',
       '#title' => $this->t('Use production environment'),
@@ -196,6 +199,13 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       '#default_value' => $this->configuration['environment_url'],
     ];
 
+    $form['client_roles'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Client roles.'),
+      '#description' => $this->t('Comma separated list of roles to be assigned to users logged in with this client.<br /> %rolelist', ['%rolelist' => implode(',', $roles)]),
+      '#default_value' => $this->configuration['client_roles'],
+    ];
+
     return $form;
   }
 
@@ -209,6 +219,18 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       return ['openid', 'email', 'ad_groups'];
     }
     return explode(',', $this->configuration['client_scopes']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getClientRoles(): array {
+    $roles = $this->configuration['client_roles'];
+
+    if (!$roles) {
+      return [];
+    }
+    return explode(',', $this->configuration['client_roles']);
   }
 
 }


### PR DESCRIPTION
Add functionality to configure roles to be added via Client configuration form. This allows us set roles per client instead of core functionality where roles are tied to ad groups.