### PR TITLE
UHF-5450: tunnistamo debug

### DIFF
--- a/src/Plugin/DebugDataItem/Tunnistamo.php
+++ b/src/Plugin/DebugDataItem/Tunnistamo.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * )
  */
 class Tunnistamo extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+
   /**
    * {@inheritdoc}
    */
@@ -36,9 +37,10 @@ class Tunnistamo extends DebugDataItemPluginBase implements ContainerFactoryPlug
     ];
 
     foreach ($data as $key => $value) {
-      $data[$key] = (bool)getenv($key);
+      $data[$key] = (bool) getenv($key);
     }
 
     return $data;
   }
+
 }

--- a/src/Plugin/DebugDataItem/Tunnistamo.php
+++ b/src/Plugin/DebugDataItem/Tunnistamo.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_tunnistamo\Plugin\DebugDataItem;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\helfi_api_base\Annotation\DebugDataItem;
+use Drupal\helfi_api_base\DebugDataItemPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Plugin implementation of the debug_data_item.
+ *
+ * @DebugDataItem(
+ *   id = "tunnistamo",
+ *   label = @Translation("Tunnistamo"),
+ *   description = @Translation("Tunnistamo")
+ * )
+ */
+class Tunnistamo extends DebugDataItemPluginBase implements ContainerFactoryPluginInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function collect(): array {
+    $data = [
+      'TUNNISTAMO_CLIENT_ID' => FALSE,
+      'TUNNISTAMO_CLIENT_SECRET' => FALSE,
+    ];
+
+    foreach ($data as $key => $value) {
+      $data[$key] = (bool)getenv($key);
+    }
+
+    return $data;
+  }
+}


### PR DESCRIPTION
# Tunnistamo debug [UHF-5450](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5450)
Added tunnistamo credential status to debug page

## What was done
* Added tunnistamo credential status to debug page

## How to install
* Make sure your instance is up and running on latest dev branch.
    * `git pull origin dev`
    * `make fresh`
* Update the HDBT Admin theme and helfi_tunnistamo module
    * `composer require drupal/hdbt_admin:dev-UHF-5450_tunnistamo_debug`
    * `composer require drupal/helfi_tunnistamo:dev-UHF-5450_tunnistamo_debug`
* Run `make drush-cr`

## How to test
* Go to debug page
* At the bottom of the page you should see the status of tunnistamo credentials

## Other PRs
* [Admin theme](https://github.com/City-of-Helsinki/drupal-hdbt-admin/pull/133)
