### PR TITLE
Allow scopes & url from config form.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/openid_connect": "^2.0"
+        "drupal/openid_connect": "^3.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",

--- a/config/schema/helfi_tunnistamo.schema.yml
+++ b/config/schema/helfi_tunnistamo.schema.yml
@@ -17,6 +17,9 @@ openid_connect.client.plugin.tunnistamo:
     environment_url:
       type: string
       label: 'Environment URL'
+    iss_allowed_domains:
+      type: string
+      label: 'Domains that are allowed to initiate SSO using ISS'
     client_scopes:
       type: string
       label: 'Client scopes'

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -199,7 +199,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       '#description' => $this->t('A comma separated list of client scopes.'),
       '#default_value' => $this->configuration['client_scopes'],
       '#size' => 255,
-      '#maxlength' => 255
+      '#maxlength' => 255,
     ];
 
     $form['environment_url'] = [
@@ -208,7 +208,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       '#description' => $this->t('Url to auth server.<br /> DEV: https://tunnistamo.test.hel.ninja<br /> PROD: https://api.hel.fi/sso <br />STAGE: https://api.hel.fi/sso-test'),
       '#default_value' => $this->configuration['environment_url'],
       '#size' => 255,
-      '#maxlength' => 255
+      '#maxlength' => 255,
     ];
 
     $roleOptions = [];

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -198,6 +198,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       '#title' => $this->t('Client scopes'),
       '#description' => $this->t('A comma separated list of client scopes.'),
       '#default_value' => $this->configuration['client_scopes'],
+      '#size' => 255,
+      '#maxlength' => 255
     ];
 
     $form['environment_url'] = [
@@ -205,6 +207,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       '#title' => $this->t('OpenID Connect Authorization server / Issuer.'),
       '#description' => $this->t('Url to auth server.<br /> DEV: https://tunnistamo.test.hel.ninja<br /> PROD: https://api.hel.fi/sso <br />STAGE: https://api.hel.fi/sso-test'),
       '#default_value' => $this->configuration['environment_url'],
+      '#size' => 255,
+      '#maxlength' => 255
     ];
 
     $roleOptions = [];

--- a/tests/src/Functional/LoginFormTest.php
+++ b/tests/src/Functional/LoginFormTest.php
@@ -17,6 +17,7 @@ class LoginFormTest extends BrowserTestBase {
    * {@inheritdoc}
    */
   protected static $modules = [
+    'file',
     'openid_connect',
     'helfi_tunnistamo',
   ];

--- a/tests/src/Kernel/KernelTestBase.php
+++ b/tests/src/Kernel/KernelTestBase.php
@@ -21,6 +21,7 @@ abstract class KernelTestBase extends CoreKernelTestBase {
     'system',
     'helfi_tunnistamo',
     'externalauth',
+    'file',
     'openid_connect',
     'user',
   ];


### PR DESCRIPTION
Scopes & url can be so long that it's not possible to insert them via config form without these changes.