### PR TITLE
UHF-6865: Attempt to detect Tunnistamo env automatically, support for end_session endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ enable `tunnistamo` client from `/admin/config/services/openid-connect`.
 
 `https://example.com/openid-connect/tunnistamo`
 
+## Detect Tunnistamo environment automatically
+
+Leave `environment_url` configuration empty and populate required `helfi_api_base.environment_resolver.settings` configuration.
+
+See [Environment resolver documentation](https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/environment-resolver.md#active-environment) for more information.
+
 ## Overriding credentials from environment variables
 
 ```

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "drupal/helfi_api_base": "*",
         "drupal/openid_connect": "^3.0"
     },
     "require-dev": {

--- a/helfi_tunnistamo.info.yml
+++ b/helfi_tunnistamo.info.yml
@@ -4,4 +4,5 @@ package: Custom
 core_version_requirement: ^9 || ^10
 
 dependencies:
+  - drupal:helfi_api_base
   - drupal:openid_connect

--- a/helfi_tunnistamo.install
+++ b/helfi_tunnistamo.install
@@ -14,7 +14,6 @@ function helfi_tunnistamo_install() : void {
   \Drupal::configFactory()
     ->getEditable('openid_connect.settings')
     ->set('override_registration_settings', TRUE)
-    ->set('connect_existing_users', FALSE)
     // Enable tunnistamo login button by default.
     ->set('user_login_display', 'below')
     // Logout from openid connect provider by default.
@@ -28,7 +27,6 @@ function helfi_tunnistamo_install() : void {
 function helfi_tunnistamo_update_9001() : void {
   Drupal::configFactory()
     ->getEditable('openid_connect.settings')
-    ->set('connect_existing_users', FALSE)
     ->set('end_session_enabled', TRUE)
     ->save();
 

--- a/helfi_tunnistamo.install
+++ b/helfi_tunnistamo.install
@@ -11,10 +11,30 @@ declare(strict_types = 1);
  * Implements hook_install().
  */
 function helfi_tunnistamo_install() : void {
-  // Enable tunnistamo login button by default.
   \Drupal::configFactory()
     ->getEditable('openid_connect.settings')
     ->set('override_registration_settings', TRUE)
+    ->set('connect_existing_users', FALSE)
+    // Enable tunnistamo login button by default.
     ->set('user_login_display', 'below')
+    // Logout from openid connect provider by default.
+    ->set('end_session_enabled', TRUE)
     ->save();
+}
+
+/**
+ * Enable logout support.
+ */
+function helfi_tunnistamo_update_9001() : void {
+  Drupal::configFactory()
+    ->getEditable('openid_connect.settings')
+    ->set('connect_existing_users', FALSE)
+    ->set('end_session_enabled', TRUE)
+    ->save();
+
+  if (!Drupal::moduleHandler()->moduleExists('helfi_api_base')) {
+    Drupal::service('module_installer')->install([
+      'helfi_api_base',
+    ]);
+  }
 }

--- a/src/EventSubscriber/HttpExceptionSubscriber.php
+++ b/src/EventSubscriber/HttpExceptionSubscriber.php
@@ -45,14 +45,14 @@ final class HttpExceptionSubscriber extends HttpExceptionSubscriberBase {
   /**
    * {@inheritdoc}
    */
-  protected static function getPriority() {
+  protected static function getPriority() : int {
     return 200;
   }
 
   /**
    * {@inheritdoc}
    */
-  protected function getHandledFormats() {
+  protected function getHandledFormats() : array {
     return ['html'];
   }
 

--- a/src/EventSubscriber/HttpExceptionSubscriber.php
+++ b/src/EventSubscriber/HttpExceptionSubscriber.php
@@ -91,7 +91,7 @@ final class HttpExceptionSubscriber extends HttpExceptionSubscriberBase {
     if (
       $event->getRequest()->query->get('error') ||
       $this->accountProxy->isAuthenticated() ||
-      $this->session->retrieveStateToken(TRUE)
+      $this->session->retrieveStateToken()
     ) {
       return;
     }

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -15,6 +15,7 @@ use Drupal\user\Entity\Role;
 use Drupal\user\UserInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements OpenID Connect Client plugin for Tunnistamo.
@@ -125,19 +126,14 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    */
-  protected function getUrlOptions(
-    string $scope,
-    GeneratedUrl $redirect_uri
-  ): array {
-    $options = parent::getUrlOptions($scope, $redirect_uri);
-
+  public function authorize(
+    string $scope = 'openid email',
+    array $additional_params = []
+  ): Response {
     if ($this->silentAuthentication) {
-      $options['query'] += [
-        'prompt' => 'none',
-      ];
+      $additional_params['prompt'] = 'none';
     }
-
-    return $options;
+    return parent::authorize($scope, $additional_params);
   }
 
   /**

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient;
 
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\GeneratedUrl;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
@@ -98,7 +100,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    */
-  public function getRedirectUrl(
+  protected function getRedirectUrl(
     array $route_parameters = [],
     array $options = []
   ): Url {
@@ -125,14 +127,47 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    */
-  public function authorize(
-    string $scope = 'openid email',
-    array $additional_params = []
-  ): Response {
+  protected function getUrlOptions(
+    string $scope,
+    GeneratedUrl $redirect_uri
+  ): array {
+    $options = parent::getUrlOptions($scope, $redirect_uri);
+
     if ($this->silentAuthentication) {
-      $additional_params['prompt'] = 'none';
+      $options['query'] += [
+        'prompt' => 'none',
+      ];
     }
-    return parent::authorize($scope, $additional_params);
+
+    return $options;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function authorize(string $scope = 'openid email', array $additional_params = []): Response {
+    // @todo Remove this override once https://www.drupal.org/project/openid_connect/issues/3317308
+    // is merged.
+    $redirect_uri = $this->getRedirectUrl()->toString(TRUE);
+    $url_options = $this->getUrlOptions($scope, $redirect_uri);
+
+    if (!empty($additional_params)) {
+      $url_options['query'] = array_merge($url_options['query'], $additional_params);
+    }
+
+    $endpoints = $this->getEndpoints();
+    // Clear _GET['destination'] because we need to override it.
+    $this->requestStack->getCurrentRequest()->query->remove('destination');
+    $authorization_endpoint = Url::fromUri($endpoints['authorization'], $url_options)->toString(TRUE);
+
+    $this->loggerFactory->get('openid_connect_' . $this->pluginId)->debug('Send authorize request to @url', ['@url' => $authorization_endpoint->getGeneratedUrl()]);
+    $response = new TrustedRedirectResponse($authorization_endpoint->getGeneratedUrl());
+    // We can't cache the response, since this will prevent the state to be
+    // added to the session. The kill switch will prevent the page getting
+    // cached for anonymous users when page cache is active.
+    $this->pageCacheKillSwitch->trigger();
+
+    return $response;
   }
 
   /**

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\GeneratedUrl;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;

--- a/tests/src/Kernel/ConfigTest.php
+++ b/tests/src/Kernel/ConfigTest.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 
+use Drupal\helfi_api_base\Environment\EnvironmentResolver;
 use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 
 /**
@@ -14,7 +15,7 @@ use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 class ConfigTest extends KernelTestBase {
 
   /**
-   * Make sure tunnistamo is enabled by default.
+   * Make sure Tunnistamo is enabled by default.
    */
   public function testEnable() : void {
     $config = $this->getPlugin()
@@ -23,7 +24,6 @@ class ConfigTest extends KernelTestBase {
     $this->assertEquals('placeholder', $config['client_secret']);
     $this->assertEquals(0, $config['auto_login']);
     $this->assertEquals([], $config['client_roles']);
-    $this->assertEquals(0, $config['is_production']);
     $this->assertEquals('', $config['environment_url']);
   }
 
@@ -40,30 +40,54 @@ class ConfigTest extends KernelTestBase {
   }
 
   /**
+   * Sets the active environment name.
+   *
+   * @param string $env
+   *   The env name.
+   */
+  private function setActiveEnvironmentName(string $env) : void {
+    $config = $this->config('helfi_api_base.environment_resolver.settings');
+    $config
+      ->set(EnvironmentResolver::ENVIRONMENT_NAME_KEY, $env)
+      ->save();
+    $this->container->get('kernel')->rebuildContainer();
+  }
+
+  /**
    * Tests environment url configuration.
    */
   public function testEndpoints() : void {
-    // Endpoint should default to testing environment.
-    $this->assertEndpoint(Tunnistamo::TESTING_ENVIRONMENT);
+    // Endpoint should default to staging environment.
+    $this->assertEndpoint(Tunnistamo::STAGING_ENVIRONMENT);
     // Make sure if we remove the environment_url setting altogether the
-    // fallback default value still fallbacks to testing env.
+    // default value still fallbacks to testing env.
     $config = $this->getPluginConfiguration();
     $settings = $config->get('settings');
     unset($settings['environment_url']);
     $config->set('settings', $settings)->save();
 
-    $this->assertEndpoint(Tunnistamo::TESTING_ENVIRONMENT);
-
-    // Endpoint should default to production environment when 'is_production' is
-    // set to true.
-    $this->setPluginConfiguration('is_production', TRUE);
-    $this->assertEndpoint(Tunnistamo::PRODUCTION_ENVIRONMENT);
+    $this->assertEndpoint(Tunnistamo::STAGING_ENVIRONMENT);
 
     // Endpoint should default to whatever we set as base url in
     // 'environment_url'.
-    $this->setPluginConfiguration('is_production', FALSE);
     $this->setPluginConfiguration('environment_url', 'https://example.com');
     $this->assertEndpoint('https://example.com');
+  }
+
+  /**
+   * Tests environment auto-detection.
+   */
+  public function testEndpointAutodetect() : void {
+    $envs = [
+      'dev' => Tunnistamo::TESTING_ENVIRONMENT,
+      'test' => Tunnistamo::TESTING_ENVIRONMENT,
+      'stage' => Tunnistamo::STAGING_ENVIRONMENT,
+      'prod' => Tunnistamo::PRODUCTION_ENVIRONMENT,
+    ];
+    foreach ($envs as $env => $url) {
+      $this->setActiveEnvironmentName($env);
+      $this->assertEndpoint($url);
+    }
   }
 
 }

--- a/tests/src/Kernel/HttpExceptionSubscriberTest.php
+++ b/tests/src/Kernel/HttpExceptionSubscriberTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tunnistamo\Kernel;
+
+use Drupal\Core\Render\HtmlResponse;
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Tests http exception subscriber.
+ *
+ * @group helfi_tunnistamo
+ */
+class HttpExceptionSubscriberTest extends KernelTestBase {
+
+  /**
+   * Run given response through the http kernel.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The handled response.
+   */
+  private function getHttpKernelResponse(Request $request) : Response {
+    $http_kernel = $this->container->get('http_kernel');
+    return $http_kernel->handle($request);
+  }
+
+  /**
+   * Make sure no redirect response is sent when auto-login is not enabled.
+   */
+  public function testAutologinDisabled() : void {
+    $request = Request::create('/admin');
+    $response = $this->getHttpKernelResponse($request);
+    $this->assertInstanceOf(HtmlResponse::class, $response);
+    $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
+  }
+
+  public function testAutologinRedirect() : void {
+    $this->setPluginConfiguration('auto_login', TRUE);
+    $request = Request::create('/admin');
+    $response = $this->getHttpKernelResponse($request);
+    $this->assertInstanceOf(TrustedRedirectResponse::class, $response);
+    $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+    $this->assertStringNotContainsString('prompt=none', $response->getTargetUrl());
+  }
+
+  /**
+   * Tests auto-login when page is served via iframe.
+   */
+  public function testAutologinRedirectIframe() : void {
+    $this->setPluginConfiguration('auto_login', TRUE);
+    // Make sure prompt=none is set.
+    $request = Request::create('/admin/content');
+    $request->headers->set('Sec-Fetch-Dest', 'iframe');
+    $response = $this->getHttpKernelResponse($request);
+    $this->assertInstanceOf(TrustedRedirectResponse::class, $response);
+    $this->assertEquals(Response::HTTP_FOUND, $response->getStatusCode());
+    $this->assertStringContainsString('prompt=none', $response->getTargetUrl());
+  }
+
+}

--- a/tests/src/Kernel/HttpExceptionSubscriberTest.php
+++ b/tests/src/Kernel/HttpExceptionSubscriberTest.php
@@ -40,6 +40,9 @@ class HttpExceptionSubscriberTest extends KernelTestBase {
     $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
   }
 
+  /**
+   * Tests auto-login on 403 pages.
+   */
   public function testAutologinRedirect() : void {
     $this->setPluginConfiguration('auto_login', TRUE);
     $request = Request::create('/admin');
@@ -50,7 +53,7 @@ class HttpExceptionSubscriberTest extends KernelTestBase {
   }
 
   /**
-   * Tests auto-login when page is served via iframe.
+   * Tests auto-login when 403 page is served via iframe.
    */
   public function testAutologinRedirectIframe() : void {
     $this->setPluginConfiguration('auto_login', TRUE);

--- a/tests/src/Kernel/HttpExceptionSubscriberTest.php
+++ b/tests/src/Kernel/HttpExceptionSubscriberTest.php
@@ -17,20 +17,6 @@ use Symfony\Component\HttpFoundation\Response;
 class HttpExceptionSubscriberTest extends KernelTestBase {
 
   /**
-   * Run given response through the http kernel.
-   *
-   * @param \Symfony\Component\HttpFoundation\Request $request
-   *   The request.
-   *
-   * @return \Symfony\Component\HttpFoundation\Response
-   *   The handled response.
-   */
-  private function getHttpKernelResponse(Request $request) : Response {
-    $http_kernel = $this->container->get('http_kernel');
-    return $http_kernel->handle($request);
-  }
-
-  /**
    * Make sure no redirect response is sent when auto-login is not enabled.
    */
   public function testAutologinDisabled() : void {

--- a/tests/src/Kernel/KernelTestBase.php
+++ b/tests/src/Kernel/KernelTestBase.php
@@ -8,6 +8,8 @@ use Drupal\Core\Config\Config;
 use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 use Drupal\KernelTests\KernelTestBase as CoreKernelTestBase;
 use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Kernel test base for tunnistamo.
@@ -70,6 +72,20 @@ abstract class KernelTestBase extends CoreKernelTestBase {
     $settings = $this->getPluginConfiguration()->get('settings');
     $settings[$key] = $value;
     $this->getPluginConfiguration()->set('settings', $settings)->save();
+  }
+
+  /**
+   * Run given response through the http kernel.
+   *
+   * @param \Symfony\Component\HttpFoundation\Request $request
+   *   The request.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The handled response.
+   */
+  protected function getHttpKernelResponse(Request $request) : Response {
+    $http_kernel = $this->container->get('http_kernel');
+    return $http_kernel->handle($request);
   }
 
 }

--- a/tests/src/Kernel/KernelTestBase.php
+++ b/tests/src/Kernel/KernelTestBase.php
@@ -19,6 +19,7 @@ abstract class KernelTestBase extends CoreKernelTestBase {
    */
   protected static $modules = [
     'system',
+    'helfi_api_base',
     'helfi_tunnistamo',
     'externalauth',
     'file',

--- a/tests/src/Kernel/RedirectUrlEventTest.php
+++ b/tests/src/Kernel/RedirectUrlEventTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\helfi_tunnistamo\Kernel;
+
+use Drupal\Core\Routing\TrustedRedirectResponse;
+use Drupal\Core\Url;
+use Drupal\helfi_tunnistamo\Event\RedirectUrlEvent;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Tests redirect url override.
+ *
+ * @group helfi_tunnistamo
+ */
+class RedirectUrlEventTest extends KernelTestBase implements EventSubscriberInterface {
+
+  /**
+   * Track caught events in a property for testing.
+   *
+   * @var array
+   */
+  private array $caughtEvents = [];
+
+  /**
+   * Catch events.
+   *
+   * @param \Drupal\helfi_tunnistamo\Event\RedirectUrlEvent $event
+   *   The event.
+   */
+  public function alterUrl(RedirectUrlEvent $event): void {
+    $event->setRedirectUrl(Url::fromUserInput('/fi/user/test')->setAbsolute());
+    $this->caughtEvents[] = $event;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      RedirectUrlEvent::class => [
+        ['alterUrl'],
+      ],
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function register(ContainerBuilder $container): void {
+    parent::register($container);
+    $container
+      ->register('testing.redirect_url_event', self::class)
+      ->addTag('event_subscriber');
+    $container->set('testing.redirect_url_event', $this);
+  }
+
+  /**
+   * Make sure authorization redirect_uri can be altered.
+   */
+  public function testAlterAuthorizeUrl() : void {
+    self::assertCount(0, $this->caughtEvents);
+    $client = $this->getPlugin();
+    $response = $client->authorize();
+    $this->assertInstanceOf(TrustedRedirectResponse::class, $response);
+    parse_str(parse_url($response->getTargetUrl(), PHP_URL_QUERY), $query);
+
+    $this->assertStringEndsWith('/fi/user/test', $query['redirect_uri']);
+
+    self::assertCount(1, $this->caughtEvents);
+  }
+
+}

--- a/tests/src/Kernel/TunnistamoClientTest.php
+++ b/tests/src/Kernel/TunnistamoClientTest.php
@@ -10,12 +10,18 @@ use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 /**
  * Tests Tunnistamo configuration.
  *
+ * @coversDefaultClass \Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo
  * @group helfi_tunnistamo
  */
-class ConfigTest extends KernelTestBase {
+class TunnistamoClientTest extends KernelTestBase {
 
   /**
    * Make sure Tunnistamo is enabled by default.
+   *
+   * @covers ::getConfiguration
+   * @covers ::defaultConfiguration
+   * @covers ::create
+   * @covers ::setConfiguration
    */
   public function testEnable() : void {
     $config = $this->getPlugin()


### PR DESCRIPTION
To test this:

- `composer update drupal/helfi_api_base` (make sure version `2.3.3` or newer is installed)
- `composer require drupal/helfi_tunnistamo:dev-UHF-6865 -W`
- `drush updb`
- `drush cr`
- `drush cex`

Make sure logging out from Drupal also logs you out from Tunnistamo.