### PR TITLE
UHF-8382

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ $config['openid_connect.client.tunnistamo']['settings']['environment_url'] = get
 ## Local development
 
 TBD: How to set up tunnistamo-authentication on local development environment.
+https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/8283226135/Helfi-tunnistamo+moduuli
 
 ## Contact
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,6 @@
 Tunnistamo client should be enabled automatically, but in case it wasn't, you can
 enable `tunnistamo` client from `/admin/config/services/openid-connect`.
 
-### Upgrading from 1.x to 2.x
-
-- Run `composer require "drupal/helfi_tunnistamo:^2.0" -W` in your project's root
-- Run database updates: `drush updb -y`
-- Delete old openid_connect clients: `rm conf/cmi/openid_connect.settings.facebook.yml conf/cmi/openid_connect.settings.generic.yml conf/cmi/openid_connect.settings.github.yml conf/cmi/openid_connect.settings.google.yml conf/cmi/openid_connect.settings.linkedin.yml conf/cmi/openid_connect.settings.tunnistamo.yml`
-- Re-create tunnistamo client from `/admin/config/people/openid-connect`
-
 ## Redirect URL
 
 `https://example.com/openid-connect/tunnistamo`

--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ $config['openid_connect.client.tunnistamo']['settings']['client_secret'] = geten
 $config['openid_connect.client.tunnistamo']['settings']['environment_url'] = getenv('TUNNISTAMO_ENVIRONMENT_URL');
 ```
 
+## Local development
+
+TBD: How to set up tunnistamo-authentication on local development environment.
+
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -21,6 +21,7 @@ function helfi_tunnistamo_openid_connect_post_authorize(UserInterface $account, 
     return;
   }
   $plugin->mapRoles($account);
+  $plugin->setUserPreferredAdminLanguage($account);
 }
 
 /**

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -344,8 +344,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    */
   public function setUserPreferredAdminLanguage(UserInterface $account) : void {
     try {
-      // If preferred admin langcode not set, set a default value.
-      if ($this->environmentResolver->getActiveEnvironmentName() &&
+      if ($this->environmentResolver->getActiveProject() &&
         !$account->getPreferredAdminLangcode(FALSE)
       ) {
         $account->set('preferred_admin_langcode', 'fi');

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -337,10 +337,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   /**
    * Set user preferred admin langcode if not set.
    *
-   * @param UserInterface $account
-   *    Account.
-   *
-   * @return void
+   * @param \Drupal\user\UserInterface $account
+   *   Account.
    */
   public function setUserPreferredAdminLanguage(UserInterface $account) : void {
     try {
@@ -351,7 +349,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
         $account->save();
       }
     }
-    catch(\Exception $e){
+    catch (\Exception $e){
       return;
     }
   }

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -342,7 +342,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    */
   public function setUserPreferredAdminLanguage(UserInterface $account) : void {
     try {
-      if ($this->environmentResolver->getActiveProject() &&
+      if (
+        $this->environmentResolver->getActiveProject() &&
         !$account->getPreferredAdminLangcode(FALSE)
       ) {
         $account->set('preferred_admin_langcode', 'fi');

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -334,4 +334,27 @@ final class Tunnistamo extends OpenIDConnectClientBase {
     return explode(',', $this->configuration['client_scopes']);
   }
 
+  /**
+   * Set user preferred admin langcode if not set.
+   *
+   * @param UserInterface $account
+   *    Account.
+   *
+   * @return void
+   */
+  public function setUserPreferredAdminLanguage(UserInterface $account) : void {
+    try {
+      // If preferred admin langcode not set, set a default value.
+      if ($this->environmentResolver->getActiveEnvironmentName() &&
+        !$account->getPreferredAdminLangcode(FALSE)
+      ) {
+        $account->set('preferred_admin_langcode', 'fi');
+        $account->save();
+      }
+    }
+    catch(\Exception $e){
+      return;
+    }
+  }
+
 }

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -349,7 +349,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
         $account->save();
       }
     }
-    catch (\Exception $e){
+    catch (\Exception $e) {
       return;
     }
   }


### PR DESCRIPTION
# [UHF-8382](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8382)
Admin user interface acts funny if preferred admin langcode is not set and you are editing translations.

## What was done
Added functionality which updates user's preferred admin langcode to FI on tunnistamo-login if user's preferred admin langcode is UND.

## How to install

Cannot be tested on local environment AFAIK.


[UHF-8382]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ