### PR TITLE
UHF-8255 Remove email from contact section that is no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,3 @@ See https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/828322613
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)
-
-Mail: `drupal@hel.fi`


### PR DESCRIPTION
Check the README that the email drupal@hel.fi is no longer in there.