### PR TITLE
UHF-9458: Fix creation of uuid usernames

### DIFF
--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
@@ -78,10 +79,7 @@ function helfi_tunnistamo_openid_connect_userinfo_alter(
 
   // Unset preferred_username if it is a UUID so that new users get their
   // name from `name` field instead.
-  if (
-    !empty($userinfo['preferred_username'])
-    && preg_match('/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/', $userinfo['preferred_username'])
-  ) {
+  if (!empty($userinfo['preferred_username']) && Uuid::isValid($userinfo['preferred_username'])) {
     unset($userinfo['preferred_username']);
   }
 

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -75,4 +75,14 @@ function helfi_tunnistamo_openid_connect_userinfo_alter(
   if (empty($userinfo['email'])) {
     $userinfo['email'] = helfi_tunnistamo_create_email($userinfo);
   }
+
+  // Unset preferred_username if it is a UUID so that new users get their
+  // name from `name` field instead.
+  if (
+    !empty($userinfo['preferred_username'])
+    && preg_match('/^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/', $userinfo['preferred_username'])
+  ) {
+    unset($userinfo['preferred_username']);
+  }
+
 }


### PR DESCRIPTION
With the new client, `preferred_username` field in `userinfo` is set to a UUID. This change removes the `preferred_username` when it is a UUID so that the `name` field is used instead.

See: https://git.drupalcode.org/project/openid_connect/-/blob/2.x/src/OpenIDConnect.php?ref_type=heads#L545-559