### PR TITLE
UHF-9857: Removed overridden ::authorize() method

### DIFF
--- a/helfi_tunnistamo.install
+++ b/helfi_tunnistamo.install
@@ -5,7 +5,7 @@
  * Contains installation tasks for 'helfi_tunnistamo' module.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Drupal\user\Entity\User;
 

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -5,7 +5,7 @@
  * Contains alterations for the Hel.fi tunnistamo module.
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 use Drupal\Component\Uuid\Uuid;
 use Drupal\Core\Form\FormStateInterface;

--- a/src/Event/RedirectUrlEvent.php
+++ b/src/Event/RedirectUrlEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\helfi_tunnistamo\Event;
 

--- a/src/EventSubscriber/HttpExceptionSubscriber.php
+++ b/src/EventSubscriber/HttpExceptionSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\helfi_tunnistamo\EventSubscriber;
 

--- a/src/Plugin/DebugDataItem/Tunnistamo.php
+++ b/src/Plugin/DebugDataItem/Tunnistamo.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\helfi_tunnistamo\Plugin\DebugDataItem;
 

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient;
 
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\helfi_tunnistamo\Event\RedirectUrlEvent;
@@ -15,7 +14,6 @@ use Drupal\user\UserInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * Implements OpenID Connect Client plugin for Tunnistamo.

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -116,34 +116,6 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   /**
    * {@inheritdoc}
    */
-  public function authorize(string $scope = 'openid email', array $additional_params = []): Response {
-    // @todo Remove this override once https://www.drupal.org/project/openid_connect/issues/3317308
-    // is merged.
-    $redirect_uri = $this->getRedirectUrl()->toString(TRUE);
-    $url_options = $this->getUrlOptions($scope, $redirect_uri);
-
-    if (!empty($additional_params)) {
-      $url_options['query'] = array_merge($url_options['query'], $additional_params);
-    }
-
-    $endpoints = $this->getEndpoints();
-    // Clear _GET['destination'] because we need to override it.
-    $this->requestStack->getCurrentRequest()->query->remove('destination');
-    $authorization_endpoint = Url::fromUri($endpoints['authorization'], $url_options)->toString(TRUE);
-
-    $this->loggerFactory->get('openid_connect_' . $this->pluginId)->debug('Send authorize request to @url', ['@url' => $authorization_endpoint->getGeneratedUrl()]);
-    $response = new TrustedRedirectResponse($authorization_endpoint->getGeneratedUrl());
-    // We can't cache the response, since this will prevent the state to be
-    // added to the session. The kill switch will prevent the page getting
-    // cached for anonymous users when page cache is active.
-    $this->pageCacheKillSwitch->trigger();
-
-    return $response;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function getEndpoints(): array {
     static $endpoints = [];
 

--- a/tests/src/Functional/LoginFormTest.php
+++ b/tests/src/Functional/LoginFormTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Functional;
 

--- a/tests/src/Kernel/HttpExceptionSubscriberTest.php
+++ b/tests/src/Kernel/HttpExceptionSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/KernelTestBase.php
+++ b/tests/src/Kernel/KernelTestBase.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/RedirectUrlEventTest.php
+++ b/tests/src/Kernel/RedirectUrlEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/RoleMapTest.php
+++ b/tests/src/Kernel/RoleMapTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/TunnistamoClientTest.php
+++ b/tests/src/Kernel/TunnistamoClientTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/TunnistamoDebugDataPluginTest.php
+++ b/tests/src/Kernel/TunnistamoDebugDataPluginTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 

--- a/tests/src/Kernel/UserInfoAlterTest.php
+++ b/tests/src/Kernel/UserInfoAlterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 


### PR DESCRIPTION
The reason this was overridden should be fixed in 3.0.0-alpha3 release.