### PR TITLE
UHF-9466: Exclude Tunnistamo users from User Expire, automatic phpcs fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,6 @@
         "drupal/helfi_api_base": "*",
         "drupal/openid_connect": "^3.0"
     },
-    "conflict": {
-        "drupal/helfi_api_base": "<=2.7.1"
-    },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3"

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,9 @@
         "drupal/helfi_api_base": "*",
         "drupal/openid_connect": "^3.0"
     },
+    "conflict": {
+        "drupal/helfi_api_base": "<=2.7.1"
+    },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "drupal/coder": "^8.3"

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -8,6 +8,8 @@
 declare(strict_types=1);
 
 use Drupal\Component\Uuid\Uuid;
+use Drupal\Core\Database\Query\AlterableInterface;
+use Drupal\Core\Database\Query\SelectInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 use Drupal\openid_connect\Entity\OpenIDConnectClientEntity;
@@ -36,7 +38,7 @@ function helfi_tunnistamo_form_user_form_alter(&$form, FormStateInterface $form_
     return;
   }
 
-  if (!\Drupal::service('externalauth.authmap')->getAll($account->id())) {
+  if (!Drupal::service('externalauth.authmap')->getAll($account->id())) {
     return;
   }
   // Prevent users from changing the email if they have used openid_connect
@@ -63,7 +65,7 @@ function helfi_tunnistamo_create_email(array $userinfo) : string {
  */
 function helfi_tunnistamo_openid_connect_userinfo_alter(
   array &$userinfo,
-  array $context
+  array $context,
 ) : void {
   $plugin = OpenIDConnectClientEntity::load($context['plugin_id'])?->getPlugin();
 
@@ -83,4 +85,17 @@ function helfi_tunnistamo_openid_connect_userinfo_alter(
     unset($userinfo['preferred_username']);
   }
 
+}
+
+/**
+ * Implements hook_query_TAG_alter().
+ *
+ * Exclude Tunnistamo users from User Expire feature.
+ */
+function helfi_tunnistamo_query_expired_users_alter(AlterableInterface $query) : void {
+  assert($query instanceof SelectInterface);
+  // Only load users that have no 'authmap' entry. This should exclude
+  // all Tunnistamo users.
+  $query->leftJoin('authmap', 'a', 'a.uid = users_field_data.uid');
+  $query->condition('a.uid', operator: 'IS NULL');
 }

--- a/src/Event/RedirectUrlEvent.php
+++ b/src/Event/RedirectUrlEvent.php
@@ -27,7 +27,7 @@ final class RedirectUrlEvent extends Event {
   public function __construct(
     private Url $redirectUrl,
     private Request $request,
-    private Tunnistamo $client
+    private Tunnistamo $client,
   ) {
   }
 

--- a/src/EventSubscriber/HttpExceptionSubscriber.php
+++ b/src/EventSubscriber/HttpExceptionSubscriber.php
@@ -29,7 +29,7 @@ final class HttpExceptionSubscriber extends HttpExceptionSubscriberBase {
   public function __construct(
     private EntityTypeManagerInterface $entityTypeManager,
     private OpenIDConnectSession $session,
-    private AccountProxyInterface $accountProxy
+    private AccountProxyInterface $accountProxy,
   ) {
   }
 

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -46,7 +46,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
     ContainerInterface $container,
     array $configuration,
     $plugin_id,
-    $plugin_definition
+    $plugin_definition,
   ) : self {
     $instance = parent::create($container, $configuration, $plugin_id, $plugin_definition);
     $instance->eventDispatcher = $container->get('event_dispatcher');
@@ -99,7 +99,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    */
   protected function getRedirectUrl(
     array $route_parameters = [],
-    array $options = []
+    array $options = [],
   ): Url {
     $url = parent::getRedirectUrl($route_parameters, $options);
     /** @var \Drupal\helfi_tunnistamo\Event\RedirectUrlEvent $urlEvent */
@@ -150,7 +150,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    */
   public function buildConfigurationForm(
     array $form,
-    FormStateInterface $form_state
+    FormStateInterface $form_state,
   ): array {
     $form = parent::buildConfigurationForm($form, $form_state);
 

--- a/tests/src/Kernel/KernelTestBase.php
+++ b/tests/src/Kernel/KernelTestBase.php
@@ -42,6 +42,7 @@ abstract class KernelTestBase extends CoreKernelTestBase {
     $this->installConfig('helfi_tunnistamo');
     $this->installEntitySchema('action');
     $this->installEntitySchema('user');
+    $this->installSchema('externalauth', ['authmap']);
 
   }
 
@@ -66,7 +67,7 @@ abstract class KernelTestBase extends CoreKernelTestBase {
     ?string $authorization = 'https://localhost/authorization',
     ?string $token = 'https://localhost/token',
     ?string $userinfo = 'https://localhost/userinfo',
-    ?string $endSession = 'https://localhost/endsession'
+    ?string $endSession = 'https://localhost/endsession',
   ) : void {
     $this->container->get('kernel')->rebuildContainer();
     $this->setPluginConfiguration('environment_url', $environmentUrl);

--- a/tests/src/Kernel/UserExpireTest.php
+++ b/tests/src/Kernel/UserExpireTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_tunnistamo\Kernel;
+
+use Drupal\helfi_api_base\Features\FeatureManager;
+use Drupal\helfi_api_base\UserExpire\UserExpireManager;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests API Base's user expiration feature with Tunnistamo.
+ *
+ * @group helfi_tunnistamo
+ */
+class UserExpireTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp() : void {
+    parent::setUp();
+
+    /** @var \Drupal\helfi_api_base\Features\FeatureManager $manager */
+    $featureManager = $this->container->get(FeatureManager::class);
+    $featureManager->enableFeature(FeatureManager::USER_EXPIRE);
+  }
+
+  /**
+   * Gets the SUT.
+   *
+   * @return \Drupal\helfi_api_base\UserExpire\UserExpireManager
+   *   The SUT.
+   */
+  public function getSut() : UserExpireManager {
+    return $this->container->get(UserExpireManager::class);
+  }
+
+  /**
+   * Tests the expired users.
+   */
+  public function testTunnistamoUsers() : void {
+    /** @var \Drupal\user\UserInterface[] $users */
+    $users = [
+      '1' => $this->createUser(),
+      '2' => $this->createUser(),
+    ];
+
+    foreach ($users as $user) {
+      // Make sure users have never logged in.
+      $this->assertEquals(0, $user->getLastAccessedTime());
+      $this->assertTrue($user->getCreatedTime() > 0);
+      // Set access time over the threshold.
+      $user->setLastAccessTime(strtotime('-7 months'))
+        ->save();
+    }
+    // Make sure both users are marked as expired.
+    $expired = $this->getSut()->getExpiredUserIds();
+    $this->assertEquals([1 => 1, 2 => 2], $expired);
+
+    /** @var \Drupal\externalauth\ExternalAuthInterface $externalAuth */
+    $externalAuth = $this->container->get('externalauth.externalauth');
+    $externalAuth->linkExistingAccount('123', 'openid_connect.tunnistamo', $users['2']);
+
+    // Make sure user 2 is not marked as expired after logging in using
+    // Tunnistamo.
+    $expired = $this->getSut()->getExpiredUserIds();
+    $this->assertArrayNotHasKey(2, $expired);
+
+    $this->getSut()->cancelExpiredUsers();
+
+    $this->assertTrue(User::load(1)->isBlocked());
+    $this->assertFalse(User::load(2)->isBlocked());
+  }
+
+}

--- a/tests/src/Kernel/UserExpireTest.php
+++ b/tests/src/Kernel/UserExpireTest.php
@@ -24,7 +24,7 @@ class UserExpireTest extends KernelTestBase {
   protected function setUp() : void {
     parent::setUp();
 
-    /** @var \Drupal\helfi_api_base\Features\FeatureManager $manager */
+    /** @var \Drupal\helfi_api_base\Features\FeatureManager $featureManager */
     $featureManager = $this->container->get(FeatureManager::class);
     $featureManager->enableFeature(FeatureManager::USER_EXPIRE);
   }

--- a/tests/src/Kernel/UserInfoAlterTest.php
+++ b/tests/src/Kernel/UserInfoAlterTest.php
@@ -26,7 +26,6 @@ class UserInfoAlterTest extends KernelTestBase {
   protected function setUp() : void {
     parent::setUp();
 
-    $this->installSchema('externalauth', ['authmap']);
     $this->installSchema('user', ['users_data']);
     $this->installConfig('user');
   }


### PR DESCRIPTION
## How to install

- composer require drupal/helfi_api_base:dev-UHF-10012 drupal/helfi_tunnistamo:dev-UHF-9466
- drush cr

## How to test

- Log in using tunnistamo
- Update your account's access time to 1: `drush sqlq "UPDATE users_field_data set access = 1 where uid = 7;"` (replace uid = 7 with your UID)
- Run `drush cron` and make sure your account did not get blocked