### PR TITLE
UHF-9515: Disable external user password on login and deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ $config['openid_connect.client.tunnistamo']['settings']['environment_url'] = 'ht
 
 See https://helsinkisolutionoffice.atlassian.net/wiki/spaces/HEL/pages/8283226135/Helfi-tunnistamo+moduuli for more information.
 
+## Preventing local user login
+
+Drupal account is created once a user has authenticated through the OpenID provider. The account cannot log without the OpenID authentication if its password is set to null. For additional safeguards, we set the password to null in [post deploy hook](https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/blob/main/documentation/deploy-hooks.md) and during login.
+
 ## Contact
 
 Slack: #helfi-drupal (http://helsinkicity.slack.com/)

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -26,6 +26,15 @@ function helfi_tunnistamo_openid_connect_post_authorize(UserInterface $account, 
   }
   $plugin->mapRoles($account, $context);
   $plugin->setUserPreferredAdminLanguage($account);
+
+  // Once user logs in with openid connect, set user password to null.
+  // This prevents the user from logging in with the local user in the
+  // future.
+  if ($account->getPassword()) {
+    $account
+      ->setPassword(NULL)
+      ->save();
+  }
 }
 
 /**

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -54,6 +54,10 @@ function helfi_tunnistamo_form_user_form_alter(&$form, FormStateInterface $form_
   // to log in.
   $form['account']['mail']['#type'] = 'item';
   $form['account']['mail']['#markup'] = $account->getEmail();
+
+  // External users password cannot be changed.
+  $form['account']['pass']['#access'] = FALSE;
+  $form['account']['current_pass']['#access'] = FALSE;
 }
 
 /**

--- a/helfi_tunnistamo.services.yml
+++ b/helfi_tunnistamo.services.yml
@@ -1,9 +1,11 @@
 services:
-  helfi_tunnistamo.http_exception_subscriber:
-    class: Drupal\helfi_tunnistamo\EventSubscriber\HttpExceptionSubscriber
-    arguments: ['@entity_type.manager', '@openid_connect.session', '@current_user']
-    tags:
-      - { name: event_subscriber }
+  _defaults:
+    autowire: true
+    autoconfigure: true
+
   logger.channel.helfi_tunnistamo:
     parent: logger.channel_base
     arguments: [ 'helfi_tunnistamo' ]
+
+  Drupal\helfi_tunnistamo\EventSubscriber\HttpExceptionSubscriber: ~
+  Drupal\helfi_tunnistamo\EventSubscriber\DisableExternalUsersPasswordSubscriber: ~

--- a/src/EventSubscriber/DisableExternalUsersPasswordSubscriber.php
+++ b/src/EventSubscriber/DisableExternalUsersPasswordSubscriber.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_tunnistamo\EventSubscriber;
+
+use Drupal\Core\Database\Connection;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\helfi_api_base\EventSubscriber\DeployHookEventSubscriberBase;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Sets tunnistamo users' password to NULL.
+ *
+ * This should prevent given users from logging in using password.
+ */
+final class DisableExternalUsersPasswordSubscriber extends DeployHookEventSubscriberBase {
+
+  /**
+   * Constructs a new instance.
+   *
+   * @param \Drupal\Core\Database\Connection $database
+   *   Database connection.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    private readonly Connection $database,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function onPostDeploy(Event $event) : void {
+    // Query tunnistamo users that have their passwords set.
+    $query = $this->database->select('authmap', 'am');
+    $query->leftJoin('users_field_data', 'ufd', 'ufd.uid = am.uid');
+    $query
+      ->fields('am', ['uid'])
+      ->condition('ufd.pass', NULL, 'IS NOT NULL')
+      // Make sure we have an upper bound.
+      ->range(0, 50);
+
+    $storage = $this->entityTypeManager->getStorage('user');
+    foreach ($query->execute()->fetchCol() as $id) {
+      /** @var \Drupal\user\UserInterface $account */
+      $account = $storage->load($id);
+
+      // Set user password to null. This prevents the user
+      // from logging in with the local user in the future.
+      $account
+        ->setPassword(NULL)
+        ->save();
+    }
+  }
+
+}

--- a/src/EventSubscriber/HttpExceptionSubscriber.php
+++ b/src/EventSubscriber/HttpExceptionSubscriber.php
@@ -9,6 +9,7 @@ use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo;
 use Drupal\openid_connect\OpenIDConnectSession;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 /**
@@ -28,6 +29,7 @@ final class HttpExceptionSubscriber extends HttpExceptionSubscriberBase {
    */
   public function __construct(
     private EntityTypeManagerInterface $entityTypeManager,
+    #[Autowire(service: 'openid_connect.session')]
     private OpenIDConnectSession $session,
     private AccountProxyInterface $accountProxy,
   ) {

--- a/tests/src/Kernel/DisableExternalUsersPasswordSubscriberTest.php
+++ b/tests/src/Kernel/DisableExternalUsersPasswordSubscriberTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_tunnistamo\Kernel;
+
+use Drupal\helfi_api_base\Event\PostDeployEvent;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use Drupal\user\Entity\User;
+
+/**
+ * Tests disable local users subscriber.
+ *
+ * @group helfi_tunnistamo
+ */
+class DisableExternalUsersPasswordSubscriberTest extends KernelTestBase {
+
+  use UserCreationTrait;
+
+  /**
+   * Tests that deploy prevents external users from logging in with password.
+   */
+  public function testSubscriber() : void {
+    /** @var \Drupal\externalauth\Authmap $authmap */
+    $authmap = $this->container->get('externalauth.authmap');
+    $external = $this->createUser(values: ['pass' => '123']);
+    $local = $this->createUser(values: ['pass' => '123']);
+
+    // Add external auth to user.
+    $authmap->save($external, 'test_provider', 'test_authname');
+
+    // User login is enabled.
+    $this->assertNotEmpty($external->getPassword());
+    $this->assertNotEmpty($local->getPassword());
+
+    $this->triggerEvent();
+
+    // User password is disabled.
+    $this->assertEmpty(User::load($external->id())->getPassword());
+    $this->assertNotEmpty(User::load($local->id())->getPassword());
+  }
+
+  /**
+   * Triggers the post deploy event.
+   */
+  private function triggerEvent() : void {
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface $service */
+    $service = $this->container->get('event_dispatcher');
+    $service->dispatch(new PostDeployEvent());
+  }
+
+}


### PR DESCRIPTION
# [UHF-9515](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9515)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Ensure tunnistamo users password must be NULL so they cannot login.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout dev`
  * `make fresh`
* Update helfi_tunnistamo
  * `composer require drupal/helfi_tunnistamo:dev-UHF-9515`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that code follows our standards
* [x] Add password for some tunnistamo user: `drush user:password 'Santeri Hurnanen_1' 'moikkamoi'`
* [x] Run post deploy hook: `drush helfi:post-deploy`
* [x] Make sure you are not able to log in with password

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR


[UHF-9515]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ