### PR TITLE
UHF-10169: eduad

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ $config['openid_connect.client.azure-ad']['settings']['ad_roles'] = [
 ];
 ```
 
+Disable role mapping for some AMRs. With this setting, OpenID users keep their manually assigned roles.
+
+```php
+$config['openid_connect.client.azure-ad']['settings']['ad_roles_disabled_amr'] = ['eduad'];
+```
+
 ## Local development
 
 Add something like this to your `local.settings.php` file:

--- a/config/schema/helfi_tunnistamo.schema.yml
+++ b/config/schema/helfi_tunnistamo.schema.yml
@@ -28,6 +28,11 @@ openid_connect.client.plugin.tunnistamo:
       label: 'Client roles to automatically map to user using this client'
       sequence:
         type: string
+    ad_roles_disabled_amr:
+      type: sequence
+      label: 'AMRs where ad role mapping is disabled'
+      sequence:
+        type: string
     ad_roles:
       type: sequence
       label: 'AD roles to automatically map to user using this client'

--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -50,10 +50,15 @@ function helfi_tunnistamo_form_user_form_alter(&$form, FormStateInterface $form_
   if (!Drupal::service('externalauth.authmap')->getAll($account->id())) {
     return;
   }
-  // Prevent users from changing the email if they have used openid_connect
-  // to log in.
-  $form['account']['mail']['#type'] = 'item';
-  $form['account']['mail']['#markup'] = $account->getEmail();
+
+  // Quick and dirty hack to enable admins to temporarily edit users emails.
+  // See: UHF-10169.
+  if (!array_intersect(['admin', 'super_administrator'], \Drupal::currentUser()->getRoles())) {
+    // Prevent users from changing the email if they have used openid_connect
+    // to log in.
+    $form['account']['mail']['#type'] = 'item';
+    $form['account']['mail']['#markup'] = $account->getEmail();
+  }
 
   // External users password cannot be changed.
   $form['account']['pass']['#access'] = FALSE;

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -231,7 +231,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    * @return array
    *   The AMR list.
    */
-  public function getDisabledAMRs() : array {
+  public function getDisabledAmr() : array {
     return array_filter($this->configuration['ad_roles_disabled_amr'] ?? []);
   }
 
@@ -252,7 +252,7 @@ final class Tunnistamo extends OpenIDConnectClientBase {
     }
 
     // Skip role mapping for configured authentication methods.
-    if (array_intersect($context['userinfo']['amr'] ?? [], $this->getDisabledAMRs())) {
+    if (array_intersect($context['userinfo']['amr'] ?? [], $this->getDisabledAmr())) {
       return;
     }
 


### PR DESCRIPTION
This is deployed to production in Kasko so admins can manually fix user info when needed.

TODO: Remove from when transition is complete.