### PR TITLE
UHF-9514: Support users without email

### DIFF
--- a/helfi_tunnistamo.module
+++ b/helfi_tunnistamo.module
@@ -41,7 +41,7 @@ function helfi_tunnistamo_openid_connect_post_authorize(UserInterface $account, 
  * Implements hook_form_FORM_ID_alter().
  */
 function helfi_tunnistamo_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) : void {
-  $mail = $form['account']['mail']['#default_value'] ?? NULL;
+  $mail = $form['account']['mail']['#default_value'] ?? '';
 
   if (!$account = user_load_by_mail($mail)) {
     return;


### PR DESCRIPTION
`user_load_by_mail()` dies to a InvalidQueryException if the user's email address is not set:

```
helfi-etusivu-app  | NOTICE: PHP message: Uncaught PHP Exception Drupal\Core\Database\InvalidQueryException: "Query condition 'users_field_data.mail IN ()' cannot be empty." at /app/public/core/lib/Drupal/Core/Database/Query/Condition.php line 106
helfi-etusivu-app  | 2024/08/05 07:26:28 [error] 50#50: *743 FastCGI sent in stderr: "PHP message: Uncaught PHP Exception Drupal\Core\Database\InvalidQueryException: "Query condition 'users_field_data.mail IN ()' cannot be empty." at /app/public/core/lib/Drupal/Core/Database/Query/Condition.php line 106" while reading response header from upstream, client: 172.29.0.2, server: _, request: "GET /en/user/193/edit HTTP/1.1", upstream: "fastcgi://127.0.0.1:9000", host: "helfi-etusivu.docker.so", referrer: "https://helfi-etusivu.docker.so/en/user/193"
```