### PR TITLE
UHF-10132: Move role mapping from helfi_helsinki_profiili to tunnistamo module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,19 @@ Disable role mapping for some AMRs. With this setting, OpenID users keep their m
 $config['openid_connect.client.azure-ad']['settings']['ad_roles_disabled_amr'] = ['eduad'];
 ```
 
+## Map level of assurance to a Drupal role
+
+The `loa` field in an OAuth token typically stands for "Level of Assurance." It is used to indicate the degree of confidence in the authentication process that was used to issue the token. The Level of Assurance reflects how certain the identity provider (IDP) is that the user is who they claim to be.
+
+```php
+$config['openid_connect.client.client`]['settings']['loa_roles'] = [
+  [
+    'loa' => 'substancial',
+    'roles' => ['has_strong_auth_rol'],
+  ],
+];
+```
+
 ## Local development
 
 Add something like this to your `local.settings.php` file:

--- a/config/install/openid_connect.client.tunnistamo.yml
+++ b/config/install/openid_connect.client.tunnistamo.yml
@@ -15,4 +15,3 @@ settings:
   client_roles: []
   ad_roles: []
   environment_url: ''
-  debug_log: false

--- a/config/install/openid_connect.client.tunnistamo.yml
+++ b/config/install/openid_connect.client.tunnistamo.yml
@@ -14,4 +14,6 @@ settings:
   auto_login: 0
   client_roles: []
   ad_roles: []
+  loa_roles: []
+  loa_no_match_roles: []
   environment_url: ''

--- a/config/install/openid_connect.client.tunnistamo.yml
+++ b/config/install/openid_connect.client.tunnistamo.yml
@@ -15,5 +15,4 @@ settings:
   client_roles: []
   ad_roles: []
   loa_roles: []
-  loa_no_match_roles: []
   environment_url: ''

--- a/config/schema/helfi_tunnistamo.schema.yml
+++ b/config/schema/helfi_tunnistamo.schema.yml
@@ -33,6 +33,24 @@ openid_connect.client.plugin.tunnistamo:
       label: 'AMRs where ad role mapping is disabled'
       sequence:
         type: string
+    loa_no_match_roles:
+      type: sequence
+      label: 'Default roles if Level of Assurance does not match mapped values'
+      nullable: true
+      sequence:
+        type: string
+    loa_roles:
+      label: 'Level of Assurance roles to automatically map to user using this client'
+      type: sequence
+      sequence:
+        type: mapping
+        mapping:
+          loa:
+            type: string
+          roles:
+            type: sequence
+            sequence:
+              type: string
     ad_roles:
       type: sequence
       label: 'AD roles to automatically map to user using this client'

--- a/config/schema/helfi_tunnistamo.schema.yml
+++ b/config/schema/helfi_tunnistamo.schema.yml
@@ -45,6 +45,3 @@ openid_connect.client.plugin.tunnistamo:
             type: sequence
             sequence:
               type: string
-    debug_log:
-      type: boolean
-      label: 'Log ad groups for debugging'

--- a/config/schema/helfi_tunnistamo.schema.yml
+++ b/config/schema/helfi_tunnistamo.schema.yml
@@ -33,12 +33,6 @@ openid_connect.client.plugin.tunnistamo:
       label: 'AMRs where ad role mapping is disabled'
       sequence:
         type: string
-    loa_no_match_roles:
-      type: sequence
-      label: 'Default roles if Level of Assurance does not match mapped values'
-      nullable: true
-      sequence:
-        type: string
     loa_roles:
       label: 'Level of Assurance roles to automatically map to user using this client'
       type: sequence

--- a/helfi_tunnistamo.services.yml
+++ b/helfi_tunnistamo.services.yml
@@ -3,9 +3,5 @@ services:
     autowire: true
     autoconfigure: true
 
-  logger.channel.helfi_tunnistamo:
-    parent: logger.channel_base
-    arguments: [ 'helfi_tunnistamo' ]
-
   Drupal\helfi_tunnistamo\EventSubscriber\HttpExceptionSubscriber: ~
   Drupal\helfi_tunnistamo\EventSubscriber\DisableExternalUsersPasswordSubscriber: ~

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -229,13 +229,6 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       return;
     }
 
-    // User groups has values when authenticated through Helsinki/Espoo AD,
-    // otherwise the variable is empty. Do not modify manually assigned roles
-    // if ad_groups variable is not set.
-    if (!isset($context['userinfo']['ad_groups'])) {
-      return;
-    }
-
     $roles = $this->getClientRoles();
     $adRoles = $this->getAdRoles();
 

--- a/src/Plugin/OpenIDConnectClient/Tunnistamo.php
+++ b/src/Plugin/OpenIDConnectClient/Tunnistamo.php
@@ -221,16 +221,6 @@ final class Tunnistamo extends OpenIDConnectClientBase {
   }
 
   /**
-   * Gets loa no match roles.
-   *
-   * @return string[]
-   *   The loa no match Drupal roles.
-   */
-  public function getLoaNoMatchRoles() : array {
-    return array_filter($this->configuration['loa_no_match_roles'] ?? []);
-  }
-
-  /**
    * Gets AMRs where ad role mapping is disabled.
    *
    * @return array
@@ -330,8 +320,8 @@ final class Tunnistamo extends OpenIDConnectClientBase {
    *   Drupal role ids.
    */
   private function mapLoaRoles(array $context) : array {
-    $roles = [];
     $loaRoles = $this->getLoaRoles();
+    $roles = [];
 
     if (!$loaRoles || empty($context['userinfo']['loa'])) {
       return [];
@@ -346,10 +336,6 @@ final class Tunnistamo extends OpenIDConnectClientBase {
       foreach ($drupalRoles as $value) {
         $roles[] = $value;
       }
-    }
-
-    if (!$roles) {
-      return $this->getLoaNoMatchRoles();
     }
 
     return $roles;

--- a/tests/src/Kernel/RoleMapTest.php
+++ b/tests/src/Kernel/RoleMapTest.php
@@ -6,9 +6,6 @@ namespace Drupal\Tests\helfi_tunnistamo\Kernel;
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Tests\user\Traits\UserCreationTrait;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Psr\Log\LoggerInterface;
 
 /**
  * Tests Tunnistamo role map functionality.
@@ -18,7 +15,6 @@ use Psr\Log\LoggerInterface;
 class RoleMapTest extends KernelTestBase {
 
   use UserCreationTrait;
-  use ProphecyTrait;
 
   /**
    * Tests that roles are mapped accordingly.
@@ -81,19 +77,6 @@ class RoleMapTest extends KernelTestBase {
       $role,
       $role2,
     ], $account->getRoles());
-  }
-
-  /**
-   * Tests group debug logging.
-   */
-  public function testDebugLogging() : void {
-    $account = $this->createUser();
-    $logger = $this->prophesize(LoggerInterface::class);
-    $logger->info(Argument::containingString('test_group'))
-      ->shouldBeCalled();
-    $this->container->set('logger.channel.helfi_tunnistamo', $logger->reveal());
-    $this->setPluginConfiguration('debug_log', TRUE);
-    $this->getPlugin()->mapRoles($account, ['userinfo' => ['ad_groups' => ['test_group']]]);
   }
 
 }

--- a/tests/src/Kernel/RoleMapTest.php
+++ b/tests/src/Kernel/RoleMapTest.php
@@ -43,17 +43,16 @@ class RoleMapTest extends KernelTestBase {
       AccountInterface::AUTHENTICATED_ROLE => AccountInterface::AUTHENTICATED_ROLE,
     ]);
 
-    $this->getPlugin()->mapRoles($account, []);
-
-    // Make sure our custom role is not removed since ad_groups was not set.
-    $this->assertEquals([
-      AccountInterface::AUTHENTICATED_ROLE,
-      $role,
-    ], $account->getRoles());
-
     $this->getPlugin()->mapRoles($account, ['userinfo' => ['ad_groups' => []]]);
 
     // Make sure our custom role is removed.
+    $this->assertEquals([
+      AccountInterface::AUTHENTICATED_ROLE,
+    ], $account->getRoles());
+
+    $this->getPlugin()->mapRoles($account, []);
+
+    // Custom roles are removed since ad_groups was not set.
     $this->assertEquals([
       AccountInterface::AUTHENTICATED_ROLE,
     ], $account->getRoles());

--- a/tests/src/Kernel/RoleMapTest.php
+++ b/tests/src/Kernel/RoleMapTest.php
@@ -71,15 +71,6 @@ class RoleMapTest extends KernelTestBase {
     ], $account->getRoles());
 
     $role2 = $this->createRole([], 'test2');
-    $this->setPluginConfiguration('loa_no_match_roles', [$role2]);
-    $this->getPlugin()->mapRoles($account, ['userinfo' => ['loa' => 'weak']]);
-
-    // Make sure loa_no_match_roles are assigned if userinfo loa is not mapped.
-    $this->assertEquals([
-      AccountInterface::AUTHENTICATED_ROLE,
-      $role2,
-    ], $account->getRoles());
-
     $role3 = $this->createRole([], 'test3');
     $this->setPluginConfiguration('client_roles', [$role => $role]);
     $this->setPluginConfiguration('ad_roles', [


### PR DESCRIPTION
# [UHF-10132](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10132)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add `loa_roles` mapping. This maps Drupal roles to user using `loa` claim from token.
* Cleanup some unused/old features.

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/hel-fi-drupal-grants/pull/1479


[UHF-10132]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ