### PR TITLE
Disable openid_connect role mapping

### DIFF
--- a/helfi_tunnistamo.install
+++ b/helfi_tunnistamo.install
@@ -20,6 +20,8 @@ function helfi_tunnistamo_install() : void {
     ->set('user_login_display', 'below')
     // Logout from openid connect provider by default.
     ->set('end_session_enabled', TRUE)
+    // Do not map roles in openid_connect module.
+    ->set('role_mappings', [])
     ->save();
 }
 
@@ -58,4 +60,18 @@ function helfi_tunnistamo_update_9003() : void {
     $account->setEmail(helfi_tunnistamo_create_email(['sub' => $sub]))
       ->save();
   }
+}
+
+/**
+ * UHF-X: Remove all openid_connect role mappings.
+ *
+ * Tunnistamo module has its own role mapping.
+ *
+ * @see \Drupal\helfi_tunnistamo\Plugin\OpenIDConnectClient\Tunnistamo::mapRoles()
+ */
+function helfi_tunnistamo_update_9004() : void {
+  \Drupal::configFactory()
+    ->getEditable('openid_connect.settings')
+    ->set('role_mappings', [])
+    ->save();
 }


### PR DESCRIPTION
OpenID connect role mapping feature was fixed in https://www.drupal.org/project/openid_connect/issues/3492759. Some of our projects have lingering configuration, so the module started to eat user roles. Helfi should not use openid_connect role mapping, since we have custom implementation.

## How to test

- `composer require drupal/helfi_tunnistamo:dev-UHF-X-kasko-role-mapping`
- `drush updb`
- `drush php:eval "print_r(Drupal::configFactory()->get('openid_connect.settings')->get('role_mappings'))"`, should return empty array.