### PR TITLE
UHF-13284: Move audit logging to tunnistamo

### DIFF
--- a/src/Hook/AuditLogHooks.php
+++ b/src/Hook/AuditLogHooks.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_tunnistamo\Hook;
+
+use Drupal\Core\Hook\Attribute\Hook;
+use Drupal\helfi_api_base\AuditLog\AuditLogServiceInterface;
+use Drupal\helfi_api_base\AuditLog\Event\AuditLogEvent;
+use Drupal\user\UserInterface;
+
+/**
+ * Audit log hooks.
+ */
+final readonly class AuditLogHooks {
+
+  public function __construct(
+    private AuditLogServiceInterface $auditLogService,
+  ) {
+  }
+
+  /**
+   * Implements hook_openid_connect_post_authorize().
+   */
+  #[Hook('openid_connect_post_authorize')]
+  public function onPostAuthorize(UserInterface $account, array $context): void {
+    $this->auditLogService->logOperation(new AuditLogEvent(
+      operation: 'TUNNISTAMO_LOGIN',
+      message: sprintf('User "%s" successfully authenticated via SSO.', $context['userinfo']['name']),
+      target: [
+        'id' => $context['userinfo']['sub'],
+        'type' => 'USER',
+        'name' => $context['userinfo']['name'],
+      ],
+    ));
+  }
+
+}


### PR DESCRIPTION
# [UHF-13284](https://helsinkisolutionoffice.atlassian.net/browse/UHF-13284)
<!-- What problem does this solve? -->

## Other PRs
<!-- For example a related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/pull/270


[UHF-13284]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-13284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ